### PR TITLE
chore(ci): fix dependabot and commitlint for strict conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,7 +53,8 @@ updates:
     open-pull-requests-limit: 5
     rebase-strategy: auto
     commit-message:
-      prefix: "chore(backend)"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
     versioning-strategy: increase-if-necessary
     # Allow only external dependencies (skip workspace:* packages)
     allow:
@@ -100,7 +101,8 @@ updates:
     open-pull-requests-limit: 5
     rebase-strategy: auto
     commit-message:
-      prefix: "chore(frontend)"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
     versioning-strategy: increase-if-necessary
     # Allow only external dependencies (skip workspace:* packages)
     allow:
@@ -162,7 +164,8 @@ updates:
     open-pull-requests-limit: 3
     rebase-strategy: auto
     commit-message:
-      prefix: "chore(application)"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
     versioning-strategy: increase-if-necessary
     # Allow only external dependencies (skip workspace:* packages)
     allow:
@@ -181,7 +184,8 @@ updates:
     open-pull-requests-limit: 3
     rebase-strategy: auto
     commit-message:
-      prefix: "chore(domain)"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
     versioning-strategy: increase-if-necessary
     # Allow only external dependencies (skip workspace:* packages)
     allow:
@@ -208,7 +212,8 @@ updates:
     open-pull-requests-limit: 3
     rebase-strategy: auto
     commit-message:
-      prefix: "chore(infrastructure)"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
     versioning-strategy: increase-if-necessary
     # Allow only external dependencies (skip workspace:* packages)
     allow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ import { Building } from '@lazy-map/domain/contexts/artificial/entities/Building
 **Format**: `type(scope): subject`
 - Subject must be **ALL lowercase** (including filenames, acronyms)
 - No period at end of subject
-- **Max 100 characters** for entire header
-- **Body lines max 100 characters** each
+- **Max 100 characters** for entire header (type + scope + subject)
+- Body lines can be any length (URLs, links are allowed)
 
 **Valid Types**:
 - `feat` - New feature

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -50,5 +50,8 @@ export default {
 
     // Header (type + scope + subject) max length
     'header-max-length': [2, 'always', 100],
+
+    // Disable body line length check (URLs and links can be long)
+    'body-max-line-length': [0, 'always', Infinity],
   },
 };


### PR DESCRIPTION
## Summary
Fixes Dependabot PR and commit generation to comply with strict
conventional commit validation rules.

## Issues Fixed
1. **Double scopes**: Dependabot was generating commits like
   `chore(backend)(deps-dev):` which failed scope validation
2. **Long body lines**: Dependabot includes URLs/links that exceed
   100 char limit in commit bodies

## Changes

### Dependabot Configuration
- Changed all npm package sections to use `chore(deps)` prefix
- Added `prefix-development` to prevent double scopes
- All dependency updates now use single `deps` scope
- Location info preserved in PR title (e.g., "in /apps/backend")

### Commitlint Configuration
- Disabled `body-max-line-length` rule
- Allows long lines in commit bodies (URLs, markdown links)
- Header still enforces 100 char limit (most important)

### Documentation
- Updated CLAUDE.md to reflect body lines can be any length
- Clarified header max is 100 chars total

## Testing
All future Dependabot PRs will now:
- Use valid single scope: `chore(deps)`
- Pass commitlint validation with long URLs in body
- Maintain useful metadata (location, changelog links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)