### PR TITLE
refactor(frontend): replace konva with html5 canvas for bundle size reduction

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -17,8 +17,6 @@
     "@lazy-map/infrastructure": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "konva": "^10.0.8",
-    "react-konva": "^19.0.0",
     "zustand": "^5.0.2",
     "@tanstack/react-query": "^5.64.0",
     "tailwindcss": "^4.1.8",


### PR DESCRIPTION
## Description

Replaced Konva.js library with native HTML5 Canvas API to significantly reduce frontend bundle size. The MapCanvas component now uses the Canvas 2D rendering context for drawing tiles, grid lines, and features.

**Bundle Size Improvement:**
- Before: 582.43 KB (182.35 KB gzipped)
- After: 270.38 KB (86.63 KB gzipped)
- **Reduction: 53.5% smaller bundle, 52.5% smaller gzipped**

**Changes:**
- Rewrote MapCanvas.tsx to use native HTML5 Canvas API
- Removed `konva` and `react-konva` dependencies from package.json
- Maintained all existing visual features (terrain, grid, feature symbols)
- PNG export now uses native `canvas.toBlob()` method

**Future-Ready:**
- Prepared for tile image loading with `ctx.drawImage()`
- Supports sprite sheets and texture atlases
- Can render images across multiple cells
- Image caching infrastructure in place

## Notes

All visual features remain identical to the Konva version. The component is now optimized for display/export use cases rather than interactive editing. This aligns with the project's goal of generating and printing tactical battlemaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>