### PR TITLE
fix(frontend): add missing Tailwind v4 Vite plugin and config reference

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@tailwindcss/vite": "^4.2.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.1.1",

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800;900&family=Urbanist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 @import "tailwindcss";
+@config "../tailwind.config.ts";
 
 @layer base {
   :root {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Description

The project was previously migrated to Tailwind v4 syntax (`@import "tailwindcss"` in `index.css`) but the required framework integration package was never installed. Without it, Tailwind v4 has no way to process the CSS import, leaving all components unstyled.

**Root cause:** Tailwind v4 decouples the core package from framework integrations. Unlike v3 (where `tailwindcss` itself shipped a PostCSS plugin), v4 requires explicitly adding either `@tailwindcss/vite` or `@tailwindcss/postcss` to the build pipeline.

**Changes:**
- Install `@tailwindcss/vite` as a dev dependency in the frontend package
- Register the Tailwind plugin in `vite.config.ts`
- Add `@config "../tailwind.config.ts"` to `index.css` so Tailwind v4 resolves the v3-style theme extensions (custom color tokens, font families) that shadcn/ui components depend on

## Notes

The `@config` directive is the Tailwind v4 backwards-compatibility bridge for v3-style `tailwind.config.ts` files. Without it, custom utility classes like `bg-background`, `text-foreground`, etc. would be unknown to the v4 engine.

---

Tests and build validation are handled by CI/CD automatically.