### PR TITLE
chore: remove deprecated husky v9 initialization pattern

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.serena/project.local.yml
+++ b/.serena/project.local.yml
@@ -1,0 +1,5 @@
+# This file allows you to locally override settings in project.yml for development purposes.
+#
+# Use the same keys as in project.yml here. Any setting you specify will override the corresponding
+# setting in project.yml, allowing you to customise the configuration for your local development environment
+# without affecting the project configuration in project.yml (which is intended to be versioned).


### PR DESCRIPTION
## Description

Removes the deprecated husky v9 initialization pattern to prepare for husky v10 compatibility.

## Changes

- Removed `#!/usr/bin/env sh` and `. "$(dirname -- "$0")/_/husky.sh"` from `.husky/commit-msg`
- Deleted the deprecated `.husky/_/` directory containing `husky.sh`

## Why

Husky v9 displays deprecation warnings:
```
husky - DEPRECATED

Please remove the following two lines from .husky/commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

## Testing

✅ Tested locally - commit hook still executes `commitlint` correctly without warnings

## Notes

This change maintains backward compatibility with husky v9 while preparing for v10.