### PR TITLE
chore(deps): add turbo clean task

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,6 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
+    "dev": "nest start --watch",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,8 @@
     "migration:create": "pnpm typeorm migration:create",
     "migration:run": "pnpm typeorm migration:run",
     "migration:revert": "pnpm typeorm migration:revert",
-    "migration:show": "pnpm typeorm migration:show"
+    "migration:show": "pnpm typeorm migration:show",
+    "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
     "@lazy-map/application": "workspace:*",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:update-snapshots": "playwright test --update-snapshots"
+    "test:e2e:update-snapshots": "playwright test --update-snapshots",
+    "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
     "@lazy-map/api-contracts": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "turbo lint",
     "lint:fix": "turbo lint:fix",
     "format": "turbo format",
+    "clean": "turbo clean && rm -rf .turbo node_modules",
     "setup": "pnpm install && turbo build --filter='@lazy-map/*'",
     "generate": "pnpm --filter @lazy-map/api-contracts generate",
     "generate:watch": "nodemon --watch apps/backend/openapi.json --exec 'pnpm generate'",

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -6,7 +6,8 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "echo 'No build needed - TypeScript types only'",
-    "generate": "openapi-typescript ../../apps/backend/openapi.json -o src/generated/types.ts && prettier --write src/generated/types.ts"
+    "generate": "openapi-typescript ../../apps/backend/openapi.json -o src/generated/types.ts && prettier --write src/generated/types.ts",
+    "clean": "rm -rf node_modules"
   },
   "devDependencies": {
     "openapi-typescript": "^7.4.4",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint src --config ../oxlint.json",
-    "lint:fix": "oxlint src --config ../oxlint.json --fix"
+    "lint:fix": "oxlint src --config ../oxlint.json --fix",
+    "clean": "rm -rf dist node_modules"
   },
   "keywords": [
     "lazy-map",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint src --config ../oxlint.json",
-    "lint:fix": "oxlint src --config ../oxlint.json --fix"
+    "lint:fix": "oxlint src --config ../oxlint.json --fix",
+    "clean": "rm -rf dist node_modules"
   },
   "keywords": ["lazy-map", "domain", "clean-architecture", "entities", "value-objects"],
   "author": "",

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest",
     "lint": "oxlint src --config ../oxlint.json",
     "lint:fix": "oxlint src --config ../oxlint.json --fix",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
     "@lazy-map/application": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,10 @@
     "format": {
       "outputs": []
     },
+    "clean": {
+      "cache": false,
+      "outputs": []
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary

- Add a `clean` script to every workspace package that removes `dist/` and `node_modules/`
- Register `clean` as a turbo task (`cache: false`, no outputs) so `turbo clean` runs across all packages in parallel
- Add root `pnpm clean` script that runs `turbo clean` then wipes `.turbo` cache and root `node_modules/`

## Usage

```bash
pnpm clean    # full reset: all dist, all node_modules, turbo cache
pnpm install  # fresh install
pnpm build    # rebuild from scratch
```

## Test plan

- [ ] Run `pnpm turbo clean --dry-run` — verify all 6 packages listed with correct commands
- [ ] Run `pnpm clean` — verify dist/, node_modules/, and .turbo are removed
- [ ] Run `pnpm install && pnpm build` — verify clean rebuild succeeds